### PR TITLE
remove illegal object extends

### DIFF
--- a/com.persistant-studios.popcornfx/Runtime/Scripts/PKFxAssets/PKFxAssetCreationUtils.cs
+++ b/com.persistant-studios.popcornfx/Runtime/Scripts/PKFxAssets/PKFxAssetCreationUtils.cs
@@ -21,7 +21,7 @@ using UnityEngine.SceneManagement;
 
 namespace PopcornFX
 {
-	public static class PKFxAssetCreationUtils : object
+	public static class PKFxAssetCreationUtils
 	{
 		public static Dictionary<int, List<PKFxEffectAsset>> m_DependenciesLoading = new Dictionary<int, List<PKFxEffectAsset>>();
 		public static Dictionary<int, List<PKFxEffectAsset>> DependenciesLoading { get { return m_DependenciesLoading; } }


### PR DESCRIPTION
While Unity will technically compile this, a static class extending object is illegal and causes errors when developing with Rider IDE.